### PR TITLE
feat: add pushover notification tool

### DIFF
--- a/tools/tool_pushover.py
+++ b/tools/tool_pushover.py
@@ -1,0 +1,71 @@
+import os
+import requests
+from gptme.tools import ToolSpec, Parameter, ToolUse
+from gptme.message import Message
+
+
+PUSHOVER_USER_KEY = os.getenv('PUSHOVER_USER_KEY')
+PUSHOVER_API_TOKEN = os.getenv('PUSHOVER_API_TOKEN')
+
+def has_pushover_conf():
+    return PUSHOVER_USER_KEY and PUSHOVER_API_TOKEN
+
+def execute(content: str | None, args: list[str] | None, kwargs: dict[str, str] | None, confirm = None) -> Message:
+    if content is not None and args is not None:
+        title = args[0]
+        message = content
+    elif kwargs is not None:
+        title = kwargs.get('title', 'No title')
+        message = kwargs.get('message', 'No message')
+    else:
+        return Message('system', "Tool call failed. Missing parameters!")
+
+    url = "https://api.pushover.net/1/messages.json"
+    payload = {
+        "token": PUSHOVER_API_TOKEN,
+        "user": PUSHOVER_USER_KEY,
+        "message": message,
+        "title": title,
+    }
+    try:
+        response = requests.post(url, data=payload, timeout=30)
+
+        if response.status_code == 200:
+            return Message('system', "Notification sent successfully")
+        else:
+            return Message('system', "The notification couldn't be sent")
+    except Exception as e:
+        return Message('system', f"Something went wrong while sending the notification: {e}")
+    
+def examples(tool_format):
+    return f"""
+> User: Send me a notification.
+> Assistant:
+{ToolUse("send_notification", ["This is a test notification!"], "Success").to_output(tool_format)}
+> System: Notification sent successfully.
+> Assistant: The notification has been sent.
+""".strip()
+
+tool = ToolSpec(
+    name="notification",
+    desc="Send a notification via Pushover push notification service.",
+    instructions="Use this tool to send notifications to the user's Pushover account.",
+    examples=examples,
+    execute=execute,
+    block_types=["notification"],
+    available=has_pushover_conf(),
+    parameters=[
+        Parameter(
+            name="message",
+            type="string",
+            description="The message to send in the notification.",
+            required=True,
+        ),
+        Parameter(
+            name="title",
+            type="string",
+            description="The title of the notification.",
+            required=False,
+        ),
+    ],
+)


### PR DESCRIPTION
Add a tool to send push notification to user phone via Pushover service.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a new tool in `tool_pushover.py` to send notifications via Pushover, with error handling and configuration checks.
> 
>   - **New Feature**:
>     - Adds `tool_pushover.py` to send notifications via Pushover.
>     - Implements `execute()` to send notifications using Pushover API.
>     - Handles missing parameters and API response errors.
>   - **Configuration**:
>     - Checks for `PUSHOVER_USER_KEY` and `PUSHOVER_API_TOKEN` environment variables in `has_pushover_conf()`.
>   - **Tool Specification**:
>     - Defines `ToolSpec` with `name`, `desc`, `instructions`, `examples`, `execute`, `block_types`, `available`, and `parameters`.
>     - Parameters include `message` (required) and `title` (optional).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ErikBjare%2Fgptme-contrib&utm_source=github&utm_medium=referral)<sup> for 890cdecbb7d99477d0d3c3045384ebf95c5a116c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->